### PR TITLE
Daemonize monitor on fork

### DIFF
--- a/gargoyle/gargoyle.cabal
+++ b/gargoyle/gargoyle.cabal
@@ -28,5 +28,6 @@ library
                , filelock == 0.1.*
                , network == 2.6.*
                , process >= 1.4 && < 1.7
+               , unix >= 2.5 && < 2.8
   hs-source-dirs: src
   default-language: Haskell2010


### PR DESCRIPTION
This prevents signals to the client that launched the monitor from killing it.