### PR TITLE
When shutting down the gargoyle daemon, explicitly kill the acceptor …

### DIFF
--- a/gargoyle/gargoyle.cabal
+++ b/gargoyle/gargoyle.cabal
@@ -1,5 +1,5 @@
 name: gargoyle
-version: 0.1
+version: 0.1.1
 license: BSD3
 license-file: LICENSE
 author: Obsidian Systems LLC

--- a/gargoyle/src/Gargoyle.hs
+++ b/gargoyle/src/Gargoyle.hs
@@ -170,6 +170,7 @@ gargoyleMain g = void $ forkProcess $ do
     shutdownVar <- newEmptyMVar
     void $ forkOS $ forever $ do
       (s, _) <- accept controlSocket
+      acceptThread <- myThreadId
       --TODO: What happens if we decide we're shutting down here?
       modifyMVar_ numClientsVar $ \n -> do
         return $ succ n
@@ -186,6 +187,8 @@ gargoyleMain g = void $ forkProcess $ do
           case pred n of
             0 -> do
               shutdown controlSocket ShutdownBoth
+              -- We have to explicitly kill the accept thread, because otherwise (sometimes?) 'accept' will begin returning EAGAIN, and ghc will continuously retry it.  This busywait consumes 100% of CPU, prevents the monitor from actually exiting, and leaves the control socket and lock file in a state where another monitor can't be started.
+              killThread acceptThread
               putMVar shutdownVar ()
             n' -> putMVar numClientsVar n'
     bracket (_gargoyle_start g (gWorkDir daemonDir)) (_gargoyle_stop g) $ \_ -> do


### PR DESCRIPTION
…thread

Surprisingly, calling `accept` nonblockingly on a socket that has already been `shutdown` will return EAGAIN.  This results in the process spinning at 100% CPU retrying the `accept`, and also not exiting properly.  With the new approach, we avoid that by killing the thread running `accept`.