### PR TITLE
Use pg_ctl instead of invoking postgres binaries directly

### DIFF
--- a/gargoyle-postgresql-nix/gargoyle-postgresql-nix.cabal
+++ b/gargoyle-postgresql-nix/gargoyle-postgresql-nix.cabal
@@ -1,5 +1,5 @@
 name: gargoyle-postgresql-nix
-version: 0.1
+version: 0.2
 author: Obsidian Systems LLC
 maintainer: maintainer@obsidian.systems
 copyright: Copyright (C) 2017 Obsidian Systems LLC
@@ -21,8 +21,8 @@ library
                , shelly
                , template-haskell
                , text
-               , gargoyle
-               , gargoyle-postgresql
+               , gargoyle == 0.1.*
+               , gargoyle-postgresql == 0.2.*
   hs-source-dirs: src
   default-language: Haskell2010
 

--- a/gargoyle-postgresql-nix/src/Gargoyle/PostgreSQL/Nix.hs
+++ b/gargoyle-postgresql-nix/src/Gargoyle/PostgreSQL/Nix.hs
@@ -3,8 +3,6 @@
 module Gargoyle.PostgreSQL.Nix where
 
 import Data.ByteString (ByteString)
-import Data.Monoid
-import System.Process
 
 import Gargoyle
 import Gargoyle.PostgreSQL
@@ -12,9 +10,9 @@ import Gargoyle.PostgreSQL
 import Paths_gargoyle_postgresql_nix
 import System.Which
 
-postgresNix :: IO (Gargoyle ProcessHandle ByteString)
+postgresNix :: IO (Gargoyle FilePath ByteString)
 postgresNix = do
   bindir <- getBinDir
-  return $ (mkPostgresGargoyle $(staticWhich "initdb") $(staticWhich "postgres") shutdownPostgresFast)
+  return $ (mkPostgresGargoyle $(staticWhich "pg_ctl") shutdownPostgresFast)
     { _gargoyle_exec = bindir <> "/gargoyle-nix-postgres-monitor"
     }

--- a/gargoyle-postgresql/gargoyle-postgresql.cabal
+++ b/gargoyle-postgresql/gargoyle-postgresql.cabal
@@ -1,5 +1,5 @@
 name: gargoyle-postgresql
-version: 0.1
+version: 0.2
 license: BSD3
 author: Obsidian Systems LLC
 maintainer: maintainer@obsidian.systems
@@ -44,6 +44,7 @@ library
                , bytestring == 0.10.*
                , directory == 1.3.*
                , gargoyle == 0.1.*
+               , posix-escape == 0.1.*
                , process >= 1.4 && < 1.7
                , stringsearch == 0.3.*
                , text == 1.2.*


### PR DESCRIPTION
This is cleaner, and, in particular, avoids needing to parse the output of `postgres` to see when the server has finished coming up (by instead using `pg_ctl start -w`).