### PR TITLE
Add initdb -A trust option

### DIFF
--- a/gargoyle-postgresql/src/Gargoyle/PostgreSQL.hs
+++ b/gargoyle-postgresql/src/Gargoyle/PostgreSQL.hs
@@ -53,6 +53,7 @@ initLocalPostgres binPath dbDir = do
       [ "-U", "postgres"
       , "--no-locale"
       , "-E", "UTF8"
+      , "-A", "trust"
       ]
     ]) { std_in = NoStream, std_out = UseHandle devNull, std_err = Inherit }
   r <- waitForProcess initdb


### PR DESCRIPTION
When initializing a database, the following warning is displayed:

```
WARNING: enabling "trust" authentication for local connections
You can change this by editing pg_hba.conf or using the option -A, or
--auth-local and --auth-host, the next time you run initdb.
```

When using Gargoyle to run tests, this warning makes the results difficult to read.  This commit adds `-A trust` to the `initdb` command in order to suppress such warnings.

Reference:

* [`initdb`](https://www.postgresql.org/docs/current/app-initdb.html)
* [authentication methods](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
* [trust authentication](https://www.postgresql.org/docs/current/auth-trust.html)