### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,3 +38,5 @@ jobs:
         if: matrix.os == 'macos-latest'
       - name: build all
         run: cabal build all
+      - name: test all
+        run: cabal test all

--- a/cabal.project
+++ b/cabal.project
@@ -3,3 +3,6 @@ packages:
     gargoyle-postgresql/
     gargoyle-postgresql-nix/
     gargoyle-postgresql-connect/
+
+package gargoyle-postgresql
+  flags: +enable-psql-test

--- a/gargoyle-postgresql/gargoyle-postgresql.cabal
+++ b/gargoyle-postgresql/gargoyle-postgresql.cabal
@@ -105,6 +105,7 @@ test-suite gargoyle-psql-test
   ghc-prof-options: -fprof-auto-exported
   hs-source-dirs:   tests
   default-language: Haskell2010
+  build-tool-depends: gargoyle-postgresql:gargoyle-postgres-monitor
 
   if !flag(enable-psql-test)
     buildable: False

--- a/gargoyle-postgresql/tests/gargoyle-psql-test.hs
+++ b/gargoyle-postgresql/tests/gargoyle-psql-test.hs
@@ -11,7 +11,7 @@ import Gargoyle.PostgreSQL
 main :: IO ()
 main = do
   let testPostgres = defaultPostgres
-        { _gargoyle_exec = "dist/build" </> "gargoyle-postgres-monitor/gargoyle-postgres-monitor"
+        { _gargoyle_exec = "gargoyle-postgres-monitor"
         }
   --TODO make this exception safe
   testPath <- mkdtemp "psql-test"

--- a/gargoyle-postgresql/tests/gargoyle-psql-test.hs
+++ b/gargoyle-postgresql/tests/gargoyle-psql-test.hs
@@ -1,5 +1,7 @@
+{-# LANGUAGE NumDecimals #-}
 module Main where
 
+import Control.Concurrent
 import System.Directory
 import System.Exit
 import System.FilePath
@@ -16,5 +18,6 @@ main = do
   --TODO make this exception safe
   testPath <- mkdtemp "psql-test"
   psqlLocal testPostgres "psql" (testPath </> "db") (Just "")
+  threadDelay 1e6 --TODO: workaround for apparent race condition when removing db/work
   removeDirectoryRecursive testPath
   exitSuccess


### PR DESCRIPTION
Fixes
```
Running 1 test suites...
Test suite gargoyle-psql-test: RUNNING...
gargoyle-psql-test: dist/build/gargoyle-postgres-monitor/gargoyle-postgres-monitor: createProcess: execvp: does not exist (No such file or directory)
HasCallStack backtrace:
  collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:92:13 in ghc-internal:GHC.Internal.Exception
  toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/IO.hs:260:11 in ghc-internal:GHC.Internal.IO
  throwIO, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:315:19 in ghc-internal:GHC.Internal.IO.Exception
  ioException, called at libraries/ghc-internal/src/GHC/Internal/IO/Exception.hs:319:20 in ghc-internal:GHC.Internal.IO.Exception
```
